### PR TITLE
docs: add cross-platform install and update guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,29 @@ To install a versioned Plugin ZIP from GitHub Releases, follow the [local Plugin
 
 Download `openai-compatible-imagegen-skill-<version>.zip` from [GitHub Releases](https://github.com/Syh1906/openai-compatible-imagegen/releases). Extract it into your client's skills directory so `SKILL.md` is at the package root, then start a new session.
 
-For the third-party [`skills`](https://www.npmjs.com/package/skills) CLI, extract the Standalone ZIP first and pass the extracted `openai-compatible-imagegen` directory as the package source. Install it for the current project by default:
+For the third-party [`skills`](https://www.npmjs.com/package/skills) CLI, extract the Standalone ZIP first and pass the extracted `openai-compatible-imagegen` directory as the package source. Install it for the current project by default.
+
+Windows PowerShell:
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS or Linux shell:
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --agent codex --skill openai-compatible-imagegen --copy --yes
 ```
 
-Add `--global` to make the Skill available to the current user across projects:
+Add `--global` to make the Skill available to the current user across projects.
+
+Windows PowerShell:
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --global --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS or Linux shell:
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent codex --skill openai-compatible-imagegen --copy --yes
@@ -73,6 +89,8 @@ npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent
 Do not pass this repository root to the CLI. Use the Skills CLI only for the first installation of an extracted Standalone archive. For scope, updates, rollback, and removal behavior, follow the [Standalone installation guide](docs/guides/installation.md#install-with-the-third-party-skills-cli).
 
 [Standalone installation paths and setup](docs/guides/installation.md#install-the-standalone-skill)
+
+For update commands, package replacement, and credential-preserving Skill switching, see [Update the Plugin or Skill](docs/guides/updating.md).
 
 ## What it does
 
@@ -101,7 +119,7 @@ The Plugin presents results and canvas actions in Codex App. The Standalone Skil
 
 ## Documentation
 
-Use the [documentation index](docs/README.md) to find installation, configuration, migration, rollback, troubleshooting, and architecture guides.
+Use the [documentation index](docs/README.md) to find installation, configuration, migration, updating, rollback, troubleshooting, and architecture guides.
 
 ## Security
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,13 +58,29 @@ Plugin 在 Windows 默认调用 `python`，在 macOS/Linux 默认调用 `python3
 
 从 [GitHub Releases](https://github.com/Syh1906/openai-compatible-imagegen/releases) 下载 `openai-compatible-imagegen-skill-<version>.zip`。解压到客户端的 skills 目录，确保包根存在 `SKILL.md`，再启动新会话。
 
-如果使用第三方 [`skills`](https://www.npmjs.com/package/skills) CLI，请先解压 Standalone ZIP，再把解压后的 `openai-compatible-imagegen` 目录作为包源。默认安装到当前项目：
+如果使用第三方 [`skills`](https://www.npmjs.com/package/skills) CLI，请先解压 Standalone ZIP，再把解压后的 `openai-compatible-imagegen` 目录作为包源。默认安装到当前项目。
+
+Windows PowerShell：
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS 或 Linux shell：
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --agent codex --skill openai-compatible-imagegen --copy --yes
 ```
 
-增加 `--global` 可安装到当前用户，在多个项目中使用：
+增加 `--global` 可安装到当前用户，在多个项目中使用。
+
+Windows PowerShell：
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --global --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS 或 Linux shell：
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent codex --skill openai-compatible-imagegen --copy --yes
@@ -73,6 +89,8 @@ npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent
 不要把本仓库根目录直接交给 CLI。Skills CLI 只用于首次安装已解压的 Standalone 压缩包。作用域、更新、回滚和卸载行为见 [Standalone 安装指南](docs/guides/installation.zh-CN.md#使用第三方-skills-cli-安装)。
 
 [Standalone 安装路径与设置](docs/guides/installation.zh-CN.md#安装-standalone-skill)
+
+更新命令、发行包替换和保留 Skill 凭据的切换方式见[更新 Plugin 或 Skill](docs/guides/updating.zh-CN.md)。
 
 ## 能做什么
 
@@ -101,7 +119,7 @@ Codex Plugin 在 App 中显示结果与画布操作。Standalone Skill 调用包
 
 ## 文档
 
-通过[文档导航](docs/README.zh-CN.md)查找安装、配置、迁移、回滚、故障排查和架构说明。
+通过[文档导航](docs/README.zh-CN.md)查找安装、配置、迁移、更新、回滚、故障排查和架构说明。
 
 ## 安全
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Use these guides to install, configure, migrate, restore, or troubleshoot OpenAI
 | Choose and install a package | [Installation](./guides/installation.md) |
 | Connect an image provider | [Configuration](./guides/configuration.md) |
 | Move an older configuration | [Migration](./guides/migration.md) |
+| Update an installed package | [Updating](./guides/updating.md) |
 | Restore a released version | [Rollback](./guides/rollback.md) |
 | Diagnose a failure | [Troubleshooting](./guides/troubleshooting.md) |
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -11,6 +11,7 @@
 | 选择并安装发行包 | [安装](./guides/installation.zh-CN.md) |
 | 连接图片服务 | [配置](./guides/configuration.zh-CN.md) |
 | 迁移旧配置 | [迁移](./guides/migration.zh-CN.md) |
+| 更新已安装发行包 | [更新](./guides/updating.zh-CN.md) |
 | 恢复已发布版本 | [回滚](./guides/rollback.zh-CN.md) |
 | 排查故障 | [故障排查](./guides/troubleshooting.zh-CN.md) |
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -11,5 +11,6 @@ Choose the guide that matches the task you need to complete.
 | Choose Standalone Skill or Codex Plugin and install it | [Installation](./installation.md) |
 | Connect an image service and set output defaults | [Configuration](./configuration.md) |
 | Move an older Standalone or Plugin configuration | [Migration](./migration.md) |
+| Update an installed Plugin or Skill | [Updating](./updating.md) |
 | Restore an earlier released package | [Rollback](./rollback.md) |
 | Resolve installation, configuration, MCP, or runtime errors | [Troubleshooting](./troubleshooting.md) |

--- a/docs/guides/README.zh-CN.md
+++ b/docs/guides/README.zh-CN.md
@@ -11,5 +11,6 @@
 | 选择 Standalone Skill 或 Codex Plugin 并完成安装 | [安装](./installation.zh-CN.md) |
 | 连接图片服务并设置输出默认值 | [配置](./configuration.zh-CN.md) |
 | 迁移旧版 Standalone 或 Plugin 配置 | [迁移](./migration.zh-CN.md) |
+| 更新已安装的 Plugin 或 Skill | [更新](./updating.zh-CN.md) |
 | 恢复较早的已发布版本 | [回滚](./rollback.zh-CN.md) |
 | 处理安装、配置、MCP 或运行时错误 | [故障排查](./troubleshooting.zh-CN.md) |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -11,10 +11,18 @@ Configure only the package you installed. The Standalone Skill and Codex Plugin 
 
 The Standalone Skill reads `auth.json` from its installed directory.
 
-1. Run the setup wizard from the installed Skill:
+1. Run the setup wizard from the installed Skill with the command for the current platform.
+
+Windows PowerShell:
 
 ```powershell
-python "<skill-root>/scripts/quick-init.py"
+python "C:/path/to/openai-compatible-imagegen/scripts/quick-init.py"
+```
+
+macOS or Linux shell:
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/scripts/quick-init.py"
 ```
 
 2. Or copy `examples/auth.example.json` to `<skill-root>/auth.json` and set:
@@ -26,10 +34,18 @@ python "<skill-root>/scripts/quick-init.py"
 | `api_key_env` | Preferred environment variable containing the credential |
 | `api_key` | Optional local plaintext credential when explicitly chosen |
 
-3. Inspect the redacted effective configuration:
+3. Inspect the redacted effective configuration with the same platform mapping.
+
+Windows PowerShell:
 
 ```powershell
-python "<skill-root>/scripts/imagegen.py" info
+python "C:/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
+```
+
+macOS or Linux shell:
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
 ```
 
 Command flags override `auth.json` defaults. Per-row JSONL fields override shared batch flags.

--- a/docs/guides/configuration.zh-CN.md
+++ b/docs/guides/configuration.zh-CN.md
@@ -11,10 +11,18 @@
 
 Standalone Skill 从安装目录读取 `auth.json`。
 
-1. 从已安装的 Skill 运行设置向导：
+1. 使用当前平台的命令，从已安装的 Skill 运行设置向导。
+
+Windows PowerShell：
 
 ```powershell
-python "<skill-root>/scripts/quick-init.py"
+python "C:/path/to/openai-compatible-imagegen/scripts/quick-init.py"
+```
+
+macOS 或 Linux shell：
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/scripts/quick-init.py"
 ```
 
 2. 或把 `examples/auth.example.json` 复制到 `<skill-root>/auth.json`，然后设置：
@@ -26,10 +34,18 @@ python "<skill-root>/scripts/quick-init.py"
 | `api_key_env` | 保存凭据的首选环境变量 |
 | `api_key` | 明确选择本地明文存储时使用的可选凭据 |
 
-3. 查看脱敏后的有效配置：
+3. 使用相同的平台映射查看脱敏后的有效配置。
+
+Windows PowerShell：
 
 ```powershell
-python "<skill-root>/scripts/imagegen.py" info
+python "C:/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
+```
+
+macOS 或 Linux shell：
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
 ```
 
 命令参数覆盖 `auth.json` 默认值。每行 JSONL 字段覆盖共享批处理参数。

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -28,6 +28,8 @@ You do not need to install both. The Codex Plugin does not depend on the Standal
 
 The Plugin includes its prebuilt MCP server and widget. You do not run `npm install`, build the repository, or start a local web server. The same Plugin archive supports Windows, macOS, and Linux.
 
+The `codex plugin` commands below are identical in Windows PowerShell, macOS Terminal, and a Linux shell. Platform-specific examples are separated only when paths or system utilities differ.
+
 The runtime selects `python` on Windows and `python3` on macOS/Linux. It requires Python 3.12 or newer. To select one explicit executable, set `OPENAI_COMPATIBLE_IMAGEGEN_PYTHON`; an invalid override or failed version preflight stops the operation and does not try another command. macOS/Linux do not expose the Windows **Show in folder** action, while generation, editing, artifacts, annotations, and canvas operations remain available.
 
 ### Steps
@@ -66,16 +68,30 @@ Use this route when you want to install a specific GitHub Release from its downl
    (Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-codex-plugin-<version>.zip").Hash.ToLowerInvariant()
    ```
 
-   macOS or Linux:
+   macOS Terminal:
+
+   ```bash
+   shasum -a 256 openai-compatible-imagegen-codex-plugin-<version>.zip
+   ```
+
+   Linux shell:
 
    ```bash
    sha256sum openai-compatible-imagegen-codex-plugin-<version>.zip
    ```
 
 3. Extract the ZIP. The extracted `openai-compatible-imagegen` directory must contain both `.codex-plugin/plugin.json` and `.agents/plugins/marketplace.json`.
-4. Add the extracted directory as a local marketplace. Use its absolute path:
+4. Add the extracted directory as a local marketplace with the path format for the current platform.
 
-   ```text
+   Windows PowerShell:
+
+   ```powershell
+   codex plugin marketplace add "C:/path/to/openai-compatible-imagegen"
+   ```
+
+   macOS or Linux shell:
+
+   ```bash
    codex plugin marketplace add "/absolute/path/to/openai-compatible-imagegen"
    ```
 
@@ -132,13 +148,29 @@ The `skills` package is a third-party Agent Skills CLI, not an OpenAI or Codex c
 | Project (default) | Current project | `<project>/.agents/skills/openai-compatible-imagegen` |
 | User (`--global`) | Current user across projects | `~/.agents/skills/openai-compatible-imagegen` |
 
-For a project installation, run the command from the target project:
+For a project installation, run the matching command from the target project.
+
+Windows PowerShell:
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS or Linux shell:
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --agent codex --skill openai-compatible-imagegen --copy --yes
 ```
 
-For a user installation, add `--global`:
+For a user installation, add `--global`.
+
+Windows PowerShell:
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --global --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS or Linux shell:
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent codex --skill openai-compatible-imagegen --copy --yes
@@ -146,17 +178,15 @@ npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent
 
 The source directory must contain `SKILL.md` at its root together with `scripts/`, `references/`, `examples/`, and `agents/`. Do not pass the repository root. A repository-root install copies Plugin, MCP, Widget, test, and documentation files into the Skill target.
 
-Both commands use `skills@latest` so new installations receive the current CLI. The `1.0.2` release verification covered copied installation and discovery at both project and user scope. Project installation creates a project `skills-lock.json`; user installation does not create that project lock file.
+Both commands use `skills@latest` so new installations receive the current CLI. A project installation creates `skills-lock.json` in the project; a user installation does not create that project lock file.
 
 Use this CLI route only for the first installation. Local copied installs have these maintenance limits:
 
 - `skills update` does not update a Skill copied from a local extracted directory at either scope.
 - Running `skills add` again replaces the installed directory and removes its local `auth.json`.
-- Project-level `skills remove` can report success while leaving the copied directory, project lock entry, and list result in place.
-- User-level `skills remove --global` removed the copied directory and list entry during the `1.0.2` verification.
 - Output files outside the installed Skill directory are not managed by these CLI operations.
 
-For an update or rollback, preserve the current installation and `auth.json`, extract the target version to a new directory, and follow the [Standalone rollback flow](./rollback.md#roll-back-the-standalone-skill). Keep generated outputs outside the installed Skill directory.
+For an update, follow [Update the Plugin or Skill](./updating.md). For a rollback, preserve the current installation and `auth.json`, extract the target version to a new directory, and follow the [Standalone rollback flow](./rollback.md#roll-back-the-standalone-skill). Keep generated outputs outside the installed Skill directory.
 
 ## Installation result
 

--- a/docs/guides/installation.zh-CN.md
+++ b/docs/guides/installation.zh-CN.md
@@ -28,6 +28,8 @@
 
 Plugin 已包含预构建的 MCP server 和 Widget。无需运行 `npm install`、构建仓库或启动本地 Web server。同一个 Plugin 压缩包支持 Windows、macOS 和 Linux。
 
+下面的 `codex plugin` 命令在 Windows PowerShell、macOS 终端和 Linux shell 中相同。只有路径或系统工具不同时才拆分平台示例。
+
 运行时在 Windows 默认调用 `python`，在 macOS/Linux 默认调用 `python3`，并要求 Python 3.12 或更高版本。需要指定一个明确的可执行文件时，设置 `OPENAI_COMPATIBLE_IMAGEGEN_PYTHON`；覆盖值无效或版本预检失败时会停止，不会尝试其他命令。macOS/Linux 不提供 Windows 的“在文件夹中显示”，但生成、编辑、产物、标注和画布操作仍可用。
 
 ### 操作步骤
@@ -66,16 +68,30 @@ codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
    (Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-codex-plugin-<version>.zip").Hash.ToLowerInvariant()
    ```
 
-   macOS 或 Linux：
+   macOS 终端：
+
+   ```bash
+   shasum -a 256 openai-compatible-imagegen-codex-plugin-<version>.zip
+   ```
+
+   Linux shell：
 
    ```bash
    sha256sum openai-compatible-imagegen-codex-plugin-<version>.zip
    ```
 
 3. 解压 ZIP。解压后的 `openai-compatible-imagegen` 目录必须同时包含 `.codex-plugin/plugin.json` 和 `.agents/plugins/marketplace.json`。
-4. 使用绝对路径把解压目录添加为本地 marketplace：
+4. 按当前平台的路径格式，把解压目录添加为本地 marketplace。
 
-   ```text
+   Windows PowerShell：
+
+   ```powershell
+   codex plugin marketplace add "C:/path/to/openai-compatible-imagegen"
+   ```
+
+   macOS 或 Linux shell：
+
+   ```bash
    codex plugin marketplace add "/absolute/path/to/openai-compatible-imagegen"
    ```
 
@@ -132,13 +148,29 @@ Codex 从 marketplace 目录安装 Plugin，不能直接从 ZIP 安装。只要�
 | 项目级（默认） | 当前项目 | `<project>/.agents/skills/openai-compatible-imagegen` |
 | 用户级（`--global`） | 当前用户的多个项目 | `~/.agents/skills/openai-compatible-imagegen` |
 
-项目级安装需要在目标项目中运行：
+项目级安装需要在目标项目中运行对应平台的命令。
+
+Windows PowerShell：
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS 或 Linux shell：
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --agent codex --skill openai-compatible-imagegen --copy --yes
 ```
 
-用户级安装需要增加 `--global`：
+用户级安装需要增加 `--global`。
+
+Windows PowerShell：
+
+```powershell
+npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --global --agent codex --skill openai-compatible-imagegen --copy --yes
+```
+
+macOS 或 Linux shell：
 
 ```text
 npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent codex --skill openai-compatible-imagegen --copy --yes
@@ -146,17 +178,15 @@ npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent
 
 源目录根部必须包含 `SKILL.md`，并同时包含 `scripts/`、`references/`、`examples/` 和 `agents/`。不要传入仓库根目录，否则 Plugin、MCP、Widget、测试和文档文件也会被复制到 Skill 目标目录。
 
-两条命令都使用 `skills@latest`，让新安装获取当前 CLI。`1.0.2` 发布验收已经覆盖项目级和用户级的复制安装与发现。项目级安装会创建项目 `skills-lock.json`；用户级安装不会创建该项目锁文件。
+两条命令都使用 `skills@latest`，让新安装获取当前 CLI。项目级安装会在项目中创建 `skills-lock.json`；用户级安装不会创建该项目锁文件。
 
 该 CLI 路线只用于首次安装。本地复制安装存在以下维护限制：
 
 - 两种作用域下，`skills update` 都不会更新从本地解压目录复制的 Skill。
 - 再次运行 `skills add` 会替换已安装目录，并删除其中的本地 `auth.json`。
-- 项目级 `skills remove` 可能报告成功，但仍保留复制目录、项目 lock 记录和列表结果。
-- `1.0.2` 验收中，用户级 `skills remove --global` 已移除复制目录和列表记录。
 - 安装目录外的输出文件不由这些 CLI 操作管理。
 
-需要更新或回滚时，保留当前安装和 `auth.json`，把目标版本解压到新目录，再按 [Standalone 回滚流程](./rollback.zh-CN.md#回滚-standalone-skill)切换。生成的图片和 manifest 应保存在已安装 Skill 目录之外。
+需要更新时，参照[更新 Plugin 或 Skill](./updating.zh-CN.md)。需要回滚时，保留当前安装和 `auth.json`，把目标版本解压到新目录，再按 [Standalone 回滚流程](./rollback.zh-CN.md#回滚-standalone-skill)切换。生成的图片和 manifest 应保存在已安装 Skill 目录之外。
 
 ## 安装结果
 

--- a/docs/guides/migration.md
+++ b/docs/guides/migration.md
@@ -16,11 +16,21 @@ Migration to the Codex Plugin is explicit. The Plugin does not scan, copy, merge
 
 ## Preview the migration
 
-Run a redacted dry run from the installed Plugin root:
+Run a redacted dry run with the command for the current platform.
+
+Windows PowerShell:
 
 ```powershell
-python "<plugin-root>/dist/scripts/migrate_image_config.py" `
-  --source "<legacy-config>" `
+python "C:/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" `
+  --source "C:/path/to/legacy/auth.json" `
+  --source-kind standalone
+```
+
+macOS or Linux shell:
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" \
+  --source "/absolute/path/to/legacy/auth.json" \
   --source-kind standalone
 ```
 
@@ -38,13 +48,25 @@ Review these fields:
 
 ## Write the migration
 
-Use the same inputs and the reviewed digest:
+Use the same inputs and the reviewed digest.
+
+Windows PowerShell:
 
 ```powershell
-python "<plugin-root>/dist/scripts/migrate_image_config.py" `
-  --source "<legacy-config>" `
+python "C:/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" `
+  --source "C:/path/to/legacy/auth.json" `
   --source-kind standalone `
   --write `
+  --expected-source-sha256 "<sourceSha256>"
+```
+
+macOS or Linux shell:
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" \
+  --source "/absolute/path/to/legacy/auth.json" \
+  --source-kind standalone \
+  --write \
   --expected-source-sha256 "<sourceSha256>"
 ```
 

--- a/docs/guides/migration.zh-CN.md
+++ b/docs/guides/migration.zh-CN.md
@@ -16,11 +16,21 @@
 
 ## 预览迁移
 
-从已安装 Plugin 根目录执行脱敏 dry run：
+使用当前平台的命令执行脱敏 dry run。
+
+Windows PowerShell：
 
 ```powershell
-python "<plugin-root>/dist/scripts/migrate_image_config.py" `
-  --source "<legacy-config>" `
+python "C:/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" `
+  --source "C:/path/to/legacy/auth.json" `
+  --source-kind standalone
+```
+
+macOS 或 Linux shell：
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" \
+  --source "/absolute/path/to/legacy/auth.json" \
   --source-kind standalone
 ```
 
@@ -38,13 +48,25 @@ python "<plugin-root>/dist/scripts/migrate_image_config.py" `
 
 ## 写入迁移结果
 
-使用相同输入和已经检查的摘要：
+使用相同输入和已经检查的摘要。
+
+Windows PowerShell：
 
 ```powershell
-python "<plugin-root>/dist/scripts/migrate_image_config.py" `
-  --source "<legacy-config>" `
+python "C:/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" `
+  --source "C:/path/to/legacy/auth.json" `
   --source-kind standalone `
   --write `
+  --expected-source-sha256 "<sourceSha256>"
+```
+
+macOS 或 Linux shell：
+
+```bash
+python3 "/absolute/path/to/openai-compatible-imagegen/dist/scripts/migrate_image_config.py" \
+  --source "/absolute/path/to/legacy/auth.json" \
+  --source-kind standalone \
+  --write \
   --expected-source-sha256 "<sourceSha256>"
 ```
 

--- a/docs/guides/rollback.md
+++ b/docs/guides/rollback.md
@@ -5,7 +5,9 @@
 
 Language: [简体中文](./rollback.zh-CN.md)
 
-Rollback changes the installed package version. It does not downgrade or rewrite your image-service configuration automatically.
+Rollback changes the installed package version. It does not downgrade or rewrite your image-service configuration automatically. For a normal forward update, use [Update the Plugin or Skill](./updating.md).
+
+The `codex plugin` rollback commands are identical in Windows PowerShell, macOS Terminal, and a Linux shell.
 
 ## Roll back the Codex Plugin
 

--- a/docs/guides/rollback.zh-CN.md
+++ b/docs/guides/rollback.zh-CN.md
@@ -5,7 +5,9 @@
 
 [English](./rollback.md) | 简体中文
 
-回滚会更改已安装发行包的版本，不会自动降级或重写图片服务配置。
+回滚会更改已安装发行包的版本，不会自动降级或重写图片服务配置。正常向前更新请使用[更新 Plugin 或 Skill](./updating.zh-CN.md)。
+
+下面的 `codex plugin` 回滚命令在 Windows PowerShell、macOS 终端和 Linux shell 中相同。
 
 ## 回滚 Codex Plugin
 

--- a/docs/guides/updating.md
+++ b/docs/guides/updating.md
@@ -1,0 +1,159 @@
+<!-- updated: 2026-08-19 -->
+# Update the Plugin or Skill
+
+> Parent: [User guides](./README.md)
+
+Language: [简体中文](./updating.zh-CN.md)
+
+Use this guide to move an existing installation to a newer released version. Updating the package does not rewrite image-service credentials, user configuration, or generated artifacts.
+
+## Before you update
+
+- Read the target release notes for breaking configuration changes.
+- Keep the current installation and local configuration until the new version passes its smoke check.
+- Download release ZIP files and `SHA256SUMS` from the same GitHub Release when you need a fixed local package.
+
+## Update a Git marketplace Plugin
+
+The marketplace command refreshes the configured Git snapshot. It is not a separate `plugin update` command and does not replace the installed Plugin by itself.
+
+The `codex plugin` lifecycle commands below are identical in Windows PowerShell, macOS Terminal, and a Linux shell. Only local paths and platform utilities differ.
+
+1. Refresh the marketplace snapshot:
+
+   ```text
+   codex plugin marketplace upgrade openai-compatible-imagegen --json
+   ```
+
+2. Replace the installed Plugin from the refreshed snapshot:
+
+   ```text
+   codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json
+   codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json
+   ```
+
+3. Confirm the installed version:
+
+   ```text
+   codex plugin list --json
+   ```
+
+4. Start a new task in Codex App or a new CLI session before using the updated Skill or MCP tools. [OpenAI's official Plugin documentation](https://developers.openai.com/codex/plugins) requires a new chat or CLI session after installation.
+
+If the marketplace source itself changed, remove and add the marketplace again before step 2. Do not use `--ref` unless you intentionally want a tag or branch snapshot.
+
+## Update from a Plugin ZIP
+
+Use this route for an offline, pinned, or archived version.
+
+1. Download `openai-compatible-imagegen-codex-plugin-<version>.zip` and `SHA256SUMS` from the same [GitHub Release](https://github.com/Syh1906/openai-compatible-imagegen/releases).
+2. Verify the ZIP digest with the command for the current platform.
+
+   Windows PowerShell:
+
+   ```powershell
+   (Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-codex-plugin-<version>.zip").Hash.ToLowerInvariant()
+   ```
+
+   macOS Terminal:
+
+   ```bash
+   shasum -a 256 openai-compatible-imagegen-codex-plugin-<version>.zip
+   ```
+
+   Linux shell:
+
+   ```bash
+   sha256sum openai-compatible-imagegen-codex-plugin-<version>.zip
+   ```
+
+3. Extract the archive to a new version-specific directory. Keep the previous directory until the new one is confirmed.
+4. Remove the old Plugin and local marketplace:
+
+   ```text
+   codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json
+   codex plugin marketplace remove openai-compatible-imagegen --json
+   ```
+
+5. Add the extracted directory with the path format for the current platform.
+
+   Windows PowerShell:
+
+   ```powershell
+   codex plugin marketplace add "C:/path/to/openai-compatible-imagegen" --json
+   ```
+
+   macOS or Linux shell:
+
+   ```bash
+   codex plugin marketplace add "/absolute/path/to/openai-compatible-imagegen" --json
+   ```
+
+6. Install and verify the Plugin:
+
+   ```text
+   codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json
+   codex plugin list --json
+   ```
+
+7. Start a new task. Keep the extracted directory while the local marketplace is configured to use it.
+
+The local marketplace route is independent from the Git marketplace route. A Git marketplace upgrade does not replace a marketplace whose source is an extracted local directory.
+
+## Update a Standalone Skill
+
+Standalone packages are copied into a client-owned Skill directory. The third-party `skills` CLI does not update a copied local source.
+
+1. Download the new `openai-compatible-imagegen-skill-<version>.zip` and `SHA256SUMS` from the same [GitHub Release](https://github.com/Syh1906/openai-compatible-imagegen/releases).
+2. Verify the Skill ZIP with the command for the current platform.
+
+   Windows PowerShell:
+
+   ```powershell
+   (Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-skill-<version>.zip").Hash.ToLowerInvariant()
+   ```
+
+   macOS Terminal:
+
+   ```bash
+   shasum -a 256 openai-compatible-imagegen-skill-<version>.zip
+   ```
+
+   Linux shell:
+
+   ```bash
+   sha256sum openai-compatible-imagegen-skill-<version>.zip
+   ```
+
+3. Extract it to a new version-specific directory. Confirm that `SKILL.md` is at the extracted package root.
+4. Copy the existing `auth.json` to the new directory only after checking that the target release accepts the same configuration. Never commit or paste its secret values.
+5. Point the client at the new directory. For a direct installation, replace the client path only after the new copy is ready.
+6. Run the bundled smoke check with the platform's Python command.
+
+   Windows PowerShell:
+
+   ```powershell
+   python "C:/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
+   ```
+
+   macOS or Linux shell:
+
+   ```bash
+   python3 "/absolute/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
+   ```
+
+7. Start a new task or session so the client reloads `SKILL.md`.
+
+Do not use `skills update` for a local copied archive. Do not run `skills add` again as an update shortcut: it can replace the installed directory and delete its local `auth.json`. Keep generated images and manifests outside the Skill directory.
+
+## Verify and recover
+
+- Plugin: `codex plugin list --json` reports the expected version and the new task exposes the Plugin tools.
+- Standalone: `imagegen.py info` resolves `script_path` and `auth_json` inside the new Skill directory.
+- If the smoke check fails, restore the previous directory and follow [Rollback](./rollback.md).
+
+## Related guides
+
+- [Installation](./installation.md)
+- [Rollback](./rollback.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/guides/updating.zh-CN.md
+++ b/docs/guides/updating.zh-CN.md
@@ -1,0 +1,159 @@
+<!-- updated: 2026-08-19 -->
+# 更新 Plugin 或 Skill
+
+> 上级：[用户指南](./README.zh-CN.md)
+
+[English](./updating.md) | 简体中文
+
+本指南用于把已有安装更新到较新的已发布版本。更新发行包不会重写图片服务凭据、用户配置或已生成的产物。
+
+## 更新前检查
+
+- 阅读目标版本的 release notes，确认配置是否有不兼容变化。
+- 在新版本通过冒烟检查前保留当前安装和本地配置。
+- 需要固定版本的本地发行包时，从同一个 GitHub Release 下载 ZIP 和 `SHA256SUMS`。
+
+## 更新 Git marketplace Plugin
+
+marketplace 命令只刷新已配置的 Git 快照；它不是单独的 `plugin update` 命令，也不会单独替换已经安装的 Plugin。
+
+下面的 `codex plugin` 生命周期命令在 Windows PowerShell、macOS 终端和 Linux shell 中相同。只有本地路径和平台工具不同。
+
+1. 刷新 marketplace 快照：
+
+   ```text
+   codex plugin marketplace upgrade openai-compatible-imagegen --json
+   ```
+
+2. 从刷新后的快照替换已安装 Plugin：
+
+   ```text
+   codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json
+   codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json
+   ```
+
+3. 确认已安装版本：
+
+   ```text
+   codex plugin list --json
+   ```
+
+4. 在 Codex App 开始新任务，或开始新的 CLI 会话，再使用更新后的 Skill 或 MCP 工具。[OpenAI 官方 Plugin 文档](https://developers.openai.com/codex/plugins)要求安装后开始新的 chat 或 CLI session。
+
+如果 marketplace 来源本身发生变化，在第 2 步前先删除并重新添加 marketplace。只有明确需要标签或分支快照时才使用 `--ref`。
+
+## 从 Plugin ZIP 更新
+
+离线、固定版本或归档场景使用这条路线。
+
+1. 从同一个 [GitHub Release](https://github.com/Syh1906/openai-compatible-imagegen/releases) 下载 `openai-compatible-imagegen-codex-plugin-<version>.zip` 和 `SHA256SUMS`。
+2. 按当前平台校验 ZIP 摘要。
+
+   Windows PowerShell：
+
+   ```powershell
+   (Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-codex-plugin-<version>.zip").Hash.ToLowerInvariant()
+   ```
+
+   macOS 终端：
+
+   ```bash
+   shasum -a 256 openai-compatible-imagegen-codex-plugin-<version>.zip
+   ```
+
+   Linux shell：
+
+   ```bash
+   sha256sum openai-compatible-imagegen-codex-plugin-<version>.zip
+   ```
+
+3. 解压到新的版本专用目录。在新目录确认前保留旧目录。
+4. 删除旧 Plugin 和本地 marketplace：
+
+   ```text
+   codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json
+   codex plugin marketplace remove openai-compatible-imagegen --json
+   ```
+
+5. 按当前平台的路径格式添加解压目录。
+
+   Windows PowerShell：
+
+   ```powershell
+   codex plugin marketplace add "C:/path/to/openai-compatible-imagegen" --json
+   ```
+
+   macOS 或 Linux shell：
+
+   ```bash
+   codex plugin marketplace add "/absolute/path/to/openai-compatible-imagegen" --json
+   ```
+
+6. 安装并确认 Plugin：
+
+   ```text
+   codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json
+   codex plugin list --json
+   ```
+
+7. 开始新任务。只要本地 marketplace 仍指向该目录，就不要删除解压目录。
+
+本地 marketplace 路线独立于 Git marketplace 路线。Git marketplace 的升级不会替换来源为本地解压目录的 marketplace。
+
+## 更新 Standalone Skill
+
+Standalone 包会复制到客户端管理的 Skill 目录。第三方 `skills` CLI 不会更新从本地来源复制的 Skill。
+
+1. 从同一个 [GitHub Release](https://github.com/Syh1906/openai-compatible-imagegen/releases) 下载新的 `openai-compatible-imagegen-skill-<version>.zip` 和 `SHA256SUMS`。
+2. 按当前平台校验 Skill ZIP。
+
+   Windows PowerShell：
+
+   ```powershell
+   (Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-skill-<version>.zip").Hash.ToLowerInvariant()
+   ```
+
+   macOS 终端：
+
+   ```bash
+   shasum -a 256 openai-compatible-imagegen-skill-<version>.zip
+   ```
+
+   Linux shell：
+
+   ```bash
+   sha256sum openai-compatible-imagegen-skill-<version>.zip
+   ```
+
+3. 解压到新的版本专用目录，确认解压包根部存在 `SKILL.md`。
+4. 只有确认目标版本接受相同配置后，才把现有 `auth.json` 复制到新目录。不要提交或粘贴其中的密钥值。
+5. 把客户端指向新目录。直接安装时，先准备好新副本，再替换客户端路径。
+6. 使用当前平台的 Python 命令运行包内冒烟检查。
+
+   Windows PowerShell：
+
+   ```powershell
+   python "C:/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
+   ```
+
+   macOS 或 Linux shell：
+
+   ```bash
+   python3 "/absolute/path/to/openai-compatible-imagegen/scripts/imagegen.py" info
+   ```
+
+7. 开始新任务或新会话，让客户端重新加载 `SKILL.md`。
+
+不要对本地复制的压缩包使用 `skills update`。不要把再次运行 `skills add` 当作更新捷径：它可能替换安装目录并删除其中的 `auth.json`。生成的图片和 manifest 应保存在 Skill 目录之外。
+
+## 验证与恢复
+
+- Plugin：`codex plugin list --json` 报告预期版本，且新任务可以使用 Plugin 工具。
+- Standalone：`imagegen.py info` 返回的 `script_path` 和 `auth_json` 都位于新的 Skill 目录内。
+- 冒烟检查失败时，恢复旧目录并参照[回滚](./rollback.zh-CN.md)。
+
+## 相关指南
+
+- [安装](./installation.zh-CN.md)
+- [回滚](./rollback.zh-CN.md)
+- [故障排查](./troubleshooting.zh-CN.md)

--- a/tests/test_git_marketplace.mjs
+++ b/tests/test_git_marketplace.mjs
@@ -65,11 +65,13 @@ test("public plugin metadata uses English defaults", async () => {
 });
 
 
-test("public install and rollback guides use the documented plugin lifecycle commands", async () => {
-  const [readme, readmeZh, installation, rollback, troubleshooting] = await Promise.all([
+test("public install, update, and rollback guides use the documented plugin lifecycle commands", async () => {
+  const [readme, readmeZh, installation, updating, updatingZh, rollback, troubleshooting] = await Promise.all([
     readFile(path.join(projectRoot, "README.md"), "utf8"),
     readFile(path.join(projectRoot, "README.zh-CN.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/installation.md"), "utf8"),
+    readFile(path.join(projectRoot, "docs/guides/updating.md"), "utf8"),
+    readFile(path.join(projectRoot, "docs/guides/updating.zh-CN.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/rollback.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/troubleshooting.md"), "utf8"),
   ]);
@@ -81,6 +83,30 @@ test("public install and rollback guides use the documented plugin lifecycle com
     assert.match(document, /codex plugin marketplace add Syh1906\/openai-compatible-imagegen/);
     assert.match(document, /codex plugin add openai-compatible-imagegen@openai-compatible-imagegen/);
   }
+  for (const document of [updating, updatingZh]) {
+    for (const command of [
+      "codex plugin marketplace upgrade openai-compatible-imagegen --json",
+      "codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json",
+      "codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json",
+      "codex plugin list --json",
+    ]) {
+      assert.ok(document.includes(command), `${command}: updating guide`);
+    }
+    for (const platformCommand of [
+      '(Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-codex-plugin-<version>.zip").Hash.ToLowerInvariant()',
+      'shasum -a 256 openai-compatible-imagegen-codex-plugin-<version>.zip',
+      'sha256sum openai-compatible-imagegen-codex-plugin-<version>.zip',
+      'codex plugin marketplace add "C:/path/to/openai-compatible-imagegen" --json',
+      'codex plugin marketplace add "/absolute/path/to/openai-compatible-imagegen" --json',
+      'python "C:/path/to/openai-compatible-imagegen/scripts/imagegen.py" info',
+      'python3 "/absolute/path/to/openai-compatible-imagegen/scripts/imagegen.py" info',
+    ]) {
+      assert.ok(document.includes(platformCommand), `${platformCommand}: updating guide`);
+    }
+    assert.match(document, /skills update/);
+    assert.match(document, /auth\.json/);
+  }
+
   for (const command of [
     "codex plugin list --json",
     "codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json",
@@ -88,6 +114,28 @@ test("public install and rollback guides use the documented plugin lifecycle com
     "codex plugin marketplace remove openai-compatible-imagegen --json",
   ]) {
     assert.ok(`${rollback}\n${troubleshooting}`.includes(command), command);
+  }
+});
+
+test("public navigation exposes the update guide from package entry points", async () => {
+  const documents = await Promise.all([
+    "README.md",
+    "README.zh-CN.md",
+    "docs/README.md",
+    "docs/README.zh-CN.md",
+    "docs/guides/README.md",
+    "docs/guides/README.zh-CN.md",
+    "docs/guides/installation.md",
+    "docs/guides/installation.zh-CN.md",
+    "docs/guides/rollback.md",
+    "docs/guides/rollback.zh-CN.md",
+  ].map(async (relativePath) => [
+    relativePath,
+    await readFile(path.join(projectRoot, relativePath), "utf8"),
+  ]));
+
+  for (const [relativePath, document] of documents) {
+    assert.match(document, /updating(?:\.zh-CN)?\.md/, relativePath);
   }
 });
 
@@ -108,6 +156,8 @@ test("English and Chinese README files keep commands and public links synchroniz
 test("public installation docs use the latest Skills CLI without pinning a package version", async () => {
   const projectCommand = "npx --yes skills@latest add /path/to/openai-compatible-imagegen --agent codex --skill openai-compatible-imagegen --copy --yes";
   const globalCommand = "npx --yes skills@latest add /path/to/openai-compatible-imagegen --global --agent codex --skill openai-compatible-imagegen --copy --yes";
+  const windowsProjectCommand = 'npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --agent codex --skill openai-compatible-imagegen --copy --yes';
+  const windowsGlobalCommand = 'npx --yes skills@latest add "C:/path/to/openai-compatible-imagegen" --global --agent codex --skill openai-compatible-imagegen --copy --yes';
 
   for (const documentPath of [
     "README.md",
@@ -118,7 +168,49 @@ test("public installation docs use the latest Skills CLI without pinning a packa
     const document = await readFile(path.join(projectRoot, documentPath), "utf8");
     assert.match(document, new RegExp(escapeRegExp(projectCommand)), documentPath);
     assert.match(document, new RegExp(escapeRegExp(globalCommand)), documentPath);
+    assert.match(document, new RegExp(escapeRegExp(windowsProjectCommand)), documentPath);
+    assert.match(document, new RegExp(escapeRegExp(windowsGlobalCommand)), documentPath);
     assert.doesNotMatch(document, /npx --yes skills@\d/, documentPath);
+  }
+});
+
+test("public command guides cover Windows, macOS, and Linux shell variants", async () => {
+  const documents = await Promise.all([
+    "docs/guides/installation.md",
+    "docs/guides/installation.zh-CN.md",
+    "docs/guides/updating.md",
+    "docs/guides/updating.zh-CN.md",
+    "docs/guides/configuration.md",
+    "docs/guides/configuration.zh-CN.md",
+    "docs/guides/migration.md",
+    "docs/guides/migration.zh-CN.md",
+  ].map(async (relativePath) => [
+    relativePath,
+    await readFile(path.join(projectRoot, relativePath), "utf8"),
+  ]));
+
+  for (const [relativePath, document] of documents) {
+    assert.match(document, /Windows PowerShell/, relativePath);
+    assert.match(document, /macOS/, relativePath);
+    assert.match(document, /Linux/, relativePath);
+  }
+
+  for (const relativePath of [
+    "docs/guides/configuration.md",
+    "docs/guides/configuration.zh-CN.md",
+  ]) {
+    const document = await readFile(path.join(projectRoot, relativePath), "utf8");
+    assert.match(document, /python "C:\/path\/to\/openai-compatible-imagegen\/scripts\/quick-init\.py"/, relativePath);
+    assert.match(document, /python3 "\/absolute\/path\/to\/openai-compatible-imagegen\/scripts\/quick-init\.py"/, relativePath);
+  }
+
+  for (const relativePath of [
+    "docs/guides/migration.md",
+    "docs/guides/migration.zh-CN.md",
+  ]) {
+    const document = await readFile(path.join(projectRoot, relativePath), "utf8");
+    assert.match(document, /python "C:\/path\/to\/openai-compatible-imagegen\/dist\/scripts\/migrate_image_config\.py"/, relativePath);
+    assert.match(document, /python3 "\/absolute\/path\/to\/openai-compatible-imagegen\/dist\/scripts\/migrate_image_config\.py"/, relativePath);
   }
 });
 
@@ -130,6 +222,7 @@ test("public docs keep localized pairs and English runtime skills", async () => 
     ["docs/guides/installation.md", "docs/guides/installation.zh-CN.md"],
     ["docs/guides/configuration.md", "docs/guides/configuration.zh-CN.md"],
     ["docs/guides/migration.md", "docs/guides/migration.zh-CN.md"],
+    ["docs/guides/updating.md", "docs/guides/updating.zh-CN.md"],
     ["docs/guides/rollback.md", "docs/guides/rollback.zh-CN.md"],
     ["docs/guides/troubleshooting.md", "docs/guides/troubleshooting.zh-CN.md"],
   ];
@@ -211,7 +304,7 @@ function fenceLanguages(markdown) {
 
 function cliCommands(markdown) {
   const commands = [];
-  const commandPattern = /^(?:\(Get-FileHash|codex|npx|python|sha256sum)\b/;
+  const commandPattern = /^(?:\(Get-FileHash|codex|npx|python3?|shasum|sha256sum)\b/;
   for (const match of markdown.matchAll(/```[^\r\n]*\r?\n([\s\S]*?)```/g)) {
     for (const line of match[1].split(/\r?\n/)) {
       const command = line.trim();


### PR DESCRIPTION
## 摘要
- 新增 Plugin 与 Standalone Skill 的双语更新指南
- 补齐 Windows、macOS、Linux 的安装、配置、迁移与校验命令
- 更新公开文档导航，并增加双语与跨平台文档契约测试

## 验证
- npm test
- npm run check
- node --test tests/test_release_artifacts.mjs
- git diff --check

## 发行影响
- 不修改版本号、CHANGELOG、运行时或发行包内容
