### PR TITLE
ci: distinguish push and pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   test:
+    name: test (${{ matrix.os }}, ${{ github.event_name }})
     strategy:
       fail-fast: false
       matrix:

--- a/tests/test_git_marketplace.mjs
+++ b/tests/test_git_marketplace.mjs
@@ -64,6 +64,12 @@ test("public plugin metadata uses English defaults", async () => {
   }
 });
 
+test("CI gives push and pull request checks distinct names", async () => {
+  const workflow = await readFile(path.join(projectRoot, ".github/workflows/ci.yml"), "utf8");
+
+  assert.match(workflow, /^\s+name: test \(\$\{\{ matrix\.os \}\}, \$\{\{ github\.event_name \}\}\)$/m);
+});
+
 
 test("public install, update, and rollback guides use the documented plugin lifecycle commands", async () => {
   const [readme, readmeZh, installation, updating, updatingZh, rollback, troubleshooting] = await Promise.all([


### PR DESCRIPTION
CI checks now include the triggering event in their names, so branch protection can require the three pull request jobs without confusing them with branch-push runs. The repository test locks in that naming contract.