### PR TITLE
fix: retry retired binding snapshots

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-compatible-imagegen",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Generate, annotate, edit, and manage OpenAI-compatible image artifacts in Codex App.",
   "author": {
     "name": "\u5c0f\u4e3a",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file records user-visible changes for each release of `openai-compatible-im
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent concurrent Codex Plugin tools from intermittently reporting a valid project binding as unavailable while another Plugin process refreshes it.
+
 ## [1.1.0] - 2026-08-19
 
 ### Added

--- a/dist/server.mjs
+++ b/dist/server.mjs
@@ -51,7 +51,7 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 var define_RELEASE_IDENTITY_default;
 var init_define_RELEASE_IDENTITY = __esm({
   "<define:__RELEASE_IDENTITY__>"() {
-    define_RELEASE_IDENTITY_default = { pluginId: "openai-compatible-imagegen", pluginVersion: "1.1.0", serverBuildDigest: "7ebb6f327b31f730fe03838cdd3920d8dbe2f9d2c797a6d968bfce472a4f55c9", widgetAssetDigest: "0808fe08666e07f61a45206d1ea3fbce86981fb968a552ee84bae77e63b30b44", fingerprint: "22ce25c8c12fe83bee33", resourceUris: { result: "ui://openai-compatible-imagegen/result-22ce25c8c12fe83bee33.html", editor: "ui://openai-compatible-imagegen/editor-22ce25c8c12fe83bee33.html" } };
+    define_RELEASE_IDENTITY_default = { pluginId: "openai-compatible-imagegen", pluginVersion: "1.1.1", serverBuildDigest: "c3d281d18c84e389284d5f7ddd513c90d90e08be1e31ae2cdc6c3e0fcd8d3c93", widgetAssetDigest: "0808fe08666e07f61a45206d1ea3fbce86981fb968a552ee84bae77e63b30b44", fingerprint: "564388874a8f326b0b8d", resourceUris: { result: "ui://openai-compatible-imagegen/result-564388874a8f326b0b8d.html", editor: "ui://openai-compatible-imagegen/editor-564388874a8f326b0b8d.html" } };
   }
 });
 
@@ -33805,7 +33805,16 @@ async function readLatestFencedFileSnapshot(recordPath, { maxBytes }) {
       return await readStableFileSnapshot(resolvedRecordPath, { maxBytes });
     }
     if (latest && initialized) {
-      return await readEpochRecord(latest.path, latest, maxBytes);
+      try {
+        const snapshot = await readEpochRecord(latest.path, latest, maxBytes);
+        if (snapshot !== null || !await hasNewerCommittedEpoch(storage.committed, latest)) {
+          return snapshot;
+        }
+      } catch (error40) {
+        if (!(error40 instanceof StableFileSnapshotError) || !await hasNewerCommittedEpoch(storage.committed, latest)) {
+          throw error40;
+        }
+      }
     }
     await delay2(1);
   }
@@ -34088,7 +34097,13 @@ async function readEpochRecord(epochPath, expected, maxBytes) {
   if (metadata.generation !== expected.generation || metadata.token !== expected.token) {
     throw new StableFileSnapshotError("invalid");
   }
-  const entries = await safeReadDirectory(epochPath);
+  let entries;
+  try {
+    entries = await safeReadDirectory(epochPath);
+  } catch (error40) {
+    if (error40?.code === "ENOENT") throw new StableFileSnapshotError("invalid");
+    throw error40;
+  }
   for (const entry of entries) {
     if (entry.isSymbolicLink() || !entry.isFile() || !["epoch.json", "record.json"].includes(entry.name)) {
       throw new StableFileSnapshotError("invalid");
@@ -34124,6 +34139,10 @@ function requireUniqueLatestEpoch(epochs) {
     throw new StableFileSnapshotError("invalid");
   }
   return latest;
+}
+async function hasNewerCommittedEpoch(committedRoot, previous) {
+  const latest = requireUniqueLatestEpoch(await listCommittedEpochs(committedRoot));
+  return latest !== null && latest.generation > previous.generation;
 }
 async function pruneCommittedEpochs(committedRoot) {
   const epochs = await listCommittedEpochs(committedRoot);

--- a/dist/widget/index.html
+++ b/dist/widget/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="openai-compatible-imagegen-release" content="22ce25c8c12fe83bee33">
+    <meta name="openai-compatible-imagegen-release" content="564388874a8f326b0b8d">
     <title>图片编辑画布</title>
     <style>
       :root {

--- a/mcp/file-lock-ownership.mjs
+++ b/mcp/file-lock-ownership.mjs
@@ -120,7 +120,19 @@ export async function readLatestFencedFileSnapshot(recordPath, { maxBytes }) {
       return await readStableFileSnapshot(resolvedRecordPath, { maxBytes });
     }
     if (latest && initialized) {
-      return await readEpochRecord(latest.path, latest, maxBytes);
+      try {
+        const snapshot = await readEpochRecord(latest.path, latest, maxBytes);
+        if (snapshot !== null || !await hasNewerCommittedEpoch(storage.committed, latest)) {
+          return snapshot;
+        }
+      } catch (error) {
+        if (
+          !(error instanceof StableFileSnapshotError)
+          || !await hasNewerCommittedEpoch(storage.committed, latest)
+        ) {
+          throw error;
+        }
+      }
     }
     await delay(1);
   }
@@ -441,7 +453,13 @@ async function readEpochRecord(epochPath, expected, maxBytes) {
   if (metadata.generation !== expected.generation || metadata.token !== expected.token) {
     throw new StableFileSnapshotError("invalid");
   }
-  const entries = await safeReadDirectory(epochPath);
+  let entries;
+  try {
+    entries = await safeReadDirectory(epochPath);
+  } catch (error) {
+    if (error?.code === "ENOENT") throw new StableFileSnapshotError("invalid");
+    throw error;
+  }
   for (const entry of entries) {
     if (
       entry.isSymbolicLink()
@@ -487,6 +505,12 @@ function requireUniqueLatestEpoch(epochs) {
     throw new StableFileSnapshotError("invalid");
   }
   return latest;
+}
+
+
+async function hasNewerCommittedEpoch(committedRoot, previous) {
+  const latest = requireUniqueLatestEpoch(await listCommittedEpochs(committedRoot));
+  return latest !== null && latest.generation > previous.generation;
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-compatible-imagegen",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-compatible-imagegen",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.5",
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-compatible-imagegen",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tests/support/project-binding-read-race-worker.mjs
+++ b/tests/support/project-binding-read-race-worker.mjs
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import path from "node:path";
+
+
+const [, , stateRoot, bindingHash, pauseAt] = process.argv;
+if (!new Set(["committed-list", "epoch-directory"]).has(pauseAt)) {
+  throw new Error("pauseAt must select a supported read race window");
+}
+const committedRoot = path.join(
+  stateRoot,
+  "project-bindings",
+  bindingHash,
+  "binding.json.epochs",
+  "committed",
+);
+const originalReaddir = fs.promises.readdir.bind(fs.promises);
+let paused = false;
+
+fs.promises.readdir = async (directory, options) => {
+  if (
+    !paused
+    && pauseAt === "epoch-directory"
+    && samePath(path.dirname(path.resolve(directory)), committedRoot)
+  ) {
+    await pauseReader();
+  }
+  const entries = await originalReaddir(directory, options);
+  if (!paused && pauseAt === "committed-list" && samePath(directory, committedRoot)) {
+    await pauseReader();
+  }
+  return entries;
+};
+syncBuiltinESMExports();
+
+const { createProjectBindingStore } = await import("../../mcp/project-binding-store.mjs");
+try {
+  await createProjectBindingStore({ stateRoot }).require(bindingHash);
+  process.stdout.write(`${JSON.stringify({ status: "ok" })}\n`);
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({ status: error?.code ?? "unexpected_error" })}\n`);
+}
+
+
+async function pauseReader() {
+  paused = true;
+  process.stdout.write("ready\n");
+  await new Promise((resolve) => process.stdin.once("data", resolve));
+}
+
+
+function samePath(left, right) {
+  const normalizedLeft = path.resolve(left).replaceAll("\\", "/");
+  const normalizedRight = path.resolve(right).replaceAll("\\", "/");
+  return process.platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}

--- a/tests/test_file_lock_ownership.mjs
+++ b/tests/test_file_lock_ownership.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { access, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -107,6 +107,68 @@ test("an initialized record never falls back to a legacy snapshot", async () => 
       (error) => error instanceof StableFileSnapshotError && error.kind === "invalid",
     );
   } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+
+test("a committed snapshot remains readable while the allocator lock exists", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "imagegen-lock-readable-"));
+  const recordPath = path.join(root, "record.json");
+  const lockPath = path.join(root, "record.lock");
+  const unavailableError = () => Object.assign(new Error("state unavailable"), {
+    code: "state_unavailable",
+  });
+  try {
+    const ownership = await acquireFileLockOwnership({
+      recordPath,
+      lockPath,
+      maxRecordBytes: 1024,
+      retries: 0,
+      unavailableError,
+    });
+    await ownership.replaceSnapshot(Buffer.from("current\n", "utf8"));
+    await ownership.release();
+    await mkdir(path.join(`${recordPath}.epochs`, "allocator.lock"));
+
+    assert.equal(
+      (await readLatestFencedFileSnapshot(recordPath, { maxBytes: 1024 })).toString("utf8"),
+      "current\n",
+    );
+  } finally {
+    await rm(root, { recursive: true });
+  }
+});
+
+
+test("a committed snapshot remains readable from a read-only epoch root", {
+  skip: process.platform === "win32",
+}, async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "imagegen-lock-read-only-"));
+  const recordPath = path.join(root, "record.json");
+  const lockPath = path.join(root, "record.lock");
+  const epochRoot = `${recordPath}.epochs`;
+  const unavailableError = () => Object.assign(new Error("state unavailable"), {
+    code: "state_unavailable",
+  });
+  try {
+    const ownership = await acquireFileLockOwnership({
+      recordPath,
+      lockPath,
+      maxRecordBytes: 1024,
+      retries: 0,
+      unavailableError,
+    });
+    await ownership.replaceSnapshot(Buffer.from("current\n", "utf8"));
+    await ownership.release();
+    await chmod(epochRoot, 0o500);
+
+    assert.equal(
+      (await readLatestFencedFileSnapshot(recordPath, { maxBytes: 1024 })).toString("utf8"),
+      "current\n",
+    );
+  } finally {
+    await chmod(epochRoot, 0o700).catch(() => {});
     await rm(root, { recursive: true });
   }
 });

--- a/tests/test_project_binding_store.mjs
+++ b/tests/test_project_binding_store.mjs
@@ -19,6 +19,10 @@ import { latestCommittedRecordPath } from "./support/fenced-record-fixture.mjs";
 
 const MODULE_PATH = fileURLToPath(new URL("../mcp/project-binding-store.mjs", import.meta.url));
 const THIS_TEST_PATH = fileURLToPath(import.meta.url);
+const READ_RACE_WORKER_PATH = fileURLToPath(
+  new URL("./support/project-binding-read-race-worker.mjs", import.meta.url),
+);
+const READ_RACE_TIMEOUT_MS = 10_000;
 const HASH_A = "a".repeat(64);
 const HASH_B = "b".repeat(64);
 const CONFIG_HASH = "c".repeat(64);
@@ -98,6 +102,75 @@ if (process.argv[2] === "--bind-worker") {
       ]);
       assert.deepEqual(parseWorkerOutcome(writer), { status: "ok" });
       assert.deepEqual(parseWorkerOutcome(reader), { status: "ok" });
+    });
+  });
+
+
+  test("a reader retries when its selected epoch is retired", async () => {
+    await withStoreRoots(async ({ stateRoot, projectA }) => {
+      const store = createProjectBindingStore({ stateRoot });
+      await store.bind(record(HASH_A, projectA));
+      const reader = spawnPausedReadRaceWorker({
+        stateRoot,
+        bindingHash: HASH_A,
+        pauseAt: "committed-list",
+      });
+      await reader.ready;
+      let outcome;
+      try {
+        await store.bind(record(HASH_A, projectA, { projectConfigSha256: HASH_B }));
+        await store.bind(record(HASH_A, projectA));
+      } finally {
+        reader.resume();
+        outcome = await reader.completed;
+      }
+      assert.deepEqual(outcome, { status: "ok" });
+    });
+  });
+
+
+  test("a reader retries when its epoch disappears after metadata validation", async () => {
+    await withStoreRoots(async ({ stateRoot, projectA }) => {
+      const store = createProjectBindingStore({ stateRoot });
+      await store.bind(record(HASH_A, projectA));
+      const reader = spawnPausedReadRaceWorker({
+        stateRoot,
+        bindingHash: HASH_A,
+        pauseAt: "epoch-directory",
+      });
+      await reader.ready;
+      let outcome;
+      try {
+        await store.bind(record(HASH_A, projectA, { projectConfigSha256: HASH_B }));
+        await store.bind(record(HASH_A, projectA));
+      } finally {
+        reader.resume();
+        outcome = await reader.completed;
+      }
+      assert.deepEqual(outcome, { status: "ok" });
+    });
+  });
+
+
+  test("a reader rejects a missing current epoch after metadata validation", async () => {
+    await withStoreRoots(async ({ stateRoot, projectA }) => {
+      const store = createProjectBindingStore({ stateRoot });
+      await store.bind(record(HASH_A, projectA));
+      const reader = spawnPausedReadRaceWorker({
+        stateRoot,
+        bindingHash: HASH_A,
+        pauseAt: "epoch-directory",
+      });
+      await reader.ready;
+      let outcome;
+      try {
+        const recordPath = await latestCommittedRecordPath(bindingPath(stateRoot, HASH_A));
+        await rm(path.dirname(recordPath), { recursive: true });
+      } finally {
+        reader.resume();
+        outcome = await reader.completed;
+      }
+      assert.deepEqual(outcome, { status: "project_binding_state_invalid" });
     });
   });
 
@@ -258,6 +331,80 @@ async function spawnStoreWorker(mode, {
     child.on("error", reject);
     child.on("close", (code) => resolve({ code, stdout, stderr }));
   });
+}
+
+
+function spawnPausedReadRaceWorker({ stateRoot, bindingHash, pauseAt }) {
+  const child = spawn(process.execPath, [READ_RACE_WORKER_PATH, stateRoot, bindingHash, pauseAt], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  let stdout = "";
+  let stderr = "";
+  let readyResolved = false;
+  let resumed = false;
+  let resolveReady;
+  let rejectReady;
+  let resolveCompleted;
+  let rejectCompleted;
+  const ready = new Promise((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const completed = new Promise((resolve, reject) => {
+    resolveCompleted = resolve;
+    rejectCompleted = reject;
+  });
+  const readyTimeout = setTimeout(() => {
+    rejectReady(new Error("race worker timed out before selecting an epoch"));
+    child.kill();
+  }, READ_RACE_TIMEOUT_MS);
+  readyTimeout.unref();
+  let completionTimeout = null;
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+    if (!readyResolved && stdout.startsWith("ready\n")) {
+      readyResolved = true;
+      clearTimeout(readyTimeout);
+      resolveReady();
+    }
+  });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  child.on("error", (error) => {
+    clearTimeout(readyTimeout);
+    if (completionTimeout !== null) clearTimeout(completionTimeout);
+    if (readyResolved) rejectCompleted(error);
+    else rejectReady(error);
+  });
+  child.on("close", (code) => {
+    clearTimeout(readyTimeout);
+    if (completionTimeout !== null) clearTimeout(completionTimeout);
+    if (!readyResolved) {
+      const error = new Error(`race worker closed before ready (${code}): ${stderr}`);
+      rejectReady(error);
+      return;
+    }
+    if (code !== 0 || stderr !== "") {
+      rejectCompleted(new Error(`race worker failed (${code}): ${stderr}`));
+      return;
+    }
+    resolveCompleted(JSON.parse(stdout.trim().split("\n").at(-1)));
+  });
+  return {
+    ready,
+    completed,
+    resume: () => {
+      if (resumed) return;
+      resumed = true;
+      completionTimeout = setTimeout(() => {
+        rejectCompleted(new Error("race worker timed out after resuming"));
+        child.kill();
+      }, READ_RACE_TIMEOUT_MS);
+      completionTimeout.unref();
+      child.stdin.end("continue\n");
+    },
+  };
 }
 
 

--- a/tests/test_release_artifacts.mjs
+++ b/tests/test_release_artifacts.mjs
@@ -254,18 +254,18 @@ test("release mode rejects baseline metadata and publishes clean artifacts for t
 });
 
 
-test("the release source builds the current v1.1.0 artifact set", async (t) => {
+test("the release source builds the current v1.1.1 artifact set", async (t) => {
   const outputDirectory = await mkdtemp(path.join(os.tmpdir(), "imagegen-release-candidate-"));
   t.after(() => rm(outputDirectory, { recursive: true, force: true }));
 
   const result = await runBuild(outputDirectory);
 
-  assert.equal(result.version, "1.1.0");
+  assert.equal(result.version, "1.1.1");
   assert.deepEqual(result.files, [
     "SHA256SUMS",
-    "openai-compatible-imagegen-codex-plugin-1.1.0.zip",
-    "openai-compatible-imagegen-shared-python-sha256-1.1.0.json",
-    "openai-compatible-imagegen-skill-1.1.0.zip",
+    "openai-compatible-imagegen-codex-plugin-1.1.1.zip",
+    "openai-compatible-imagegen-shared-python-sha256-1.1.1.json",
+    "openai-compatible-imagegen-skill-1.1.1.zip",
   ]);
   assert.deepEqual((await readdir(outputDirectory)).sort(), result.files);
 });


### PR DESCRIPTION
Concurrent Plugin processes could retire a project-binding snapshot after a reader selected it but before the reader finished opening its files. The reader now re-enumerates only when a newer generation has been committed; missing or damaged state in the current generation still fails closed.

This includes deterministic cross-process coverage for both retirement windows, keeps committed snapshots readable without taking the allocator lock, and advances the Plugin candidate identity to 1.1.1.