### PR TITLE
docs: clarify Git marketplace update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ codex plugin marketplace add Syh1906/openai-compatible-imagegen
 codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
 ```
 
+If the `openai-compatible-imagegen` marketplace is already registered, skip the first command. After installation, completely quit and restart Codex once so it loads the Plugin's Skill, MCP tools, and bundled dependencies.
+
 You can also open **Plugins** in Codex App, select the `openai-compatible-imagegen` marketplace, and install **OpenAI-Compatible Images**. In an interactive Codex CLI session, enter `/plugins` to use the same browser.
 
 The Git-backed package already contains the MCP server and widget. You do not build the repository or run a local web server.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,8 @@ codex plugin marketplace add Syh1906/openai-compatible-imagegen
 codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
 ```
 
+如果 `openai-compatible-imagegen` marketplace 已注册，跳过第一条命令。安装后完全退出并重新启动 Codex 一次，让 Plugin 的 Skill、MCP 工具和包内依赖完整加载。
+
 你也可以在 Codex App 打开 **Plugins**，选择 `openai-compatible-imagegen` marketplace，安装 **OpenAI-Compatible Images**。交互式 Codex CLI 会话可输入 `/plugins` 打开同一浏览器。
 
 Git-backed 安装已经包含 MCP server 和 widget，不需要构建仓库或启动本地 Web 服务。

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-08-19 -->
+<!-- updated: 2026-08-20 -->
 # Installation
 
 > Parent: [User guides](./README.md)
@@ -40,6 +40,8 @@ The runtime selects `python` on Windows and `python3` on macOS/Linux. It require
 codex plugin marketplace add Syh1906/openai-compatible-imagegen
 ```
 
+If the `openai-compatible-imagegen` marketplace is already registered, skip this step.
+
 2. Install the Plugin:
 
 ```text
@@ -48,7 +50,7 @@ codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
 
 3. Alternatively, open **Plugins** in Codex App or enter `/plugins` in an interactive Codex CLI session, select the `openai-compatible-imagegen` marketplace, and install **OpenAI-Compatible Images**.
 4. Confirm the installed version with `codex plugin list --json`.
-5. Start a new task after installation.
+5. Completely quit and restart Codex once after installation, then start a new task.
 6. Continue with [Plugin configuration](./configuration.md#configure-the-codex-plugin).
 
 The first configuration can also be created from a new task by asking the Agent to call `initialize_image_config`. Use `inspect_image_config` to review the redacted result and `update_image_config` for supported changes; the Plugin installation directory and Skill directory do not contain the user configuration.
@@ -101,7 +103,7 @@ Use this route when you want to install a specific GitHub Release from its downl
    codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
    ```
 
-6. Confirm the installed version with `codex plugin list --json`, then start a new task.
+6. Confirm the installed version with `codex plugin list --json`. Completely quit and restart Codex once, then start a new task.
 7. Continue with [Plugin configuration](./configuration.md#configure-the-codex-plugin).
 
 Codex installs plugins from marketplace directories, not directly from ZIP files. Keep the extracted directory while this local marketplace remains configured. The Git-backed marketplace remains the recommended route for normal updates.

--- a/docs/guides/installation.zh-CN.md
+++ b/docs/guides/installation.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- updated: 2026-08-19 -->
+<!-- updated: 2026-08-20 -->
 # 安装
 
 > 上级：[用户指南](./README.zh-CN.md)
@@ -40,6 +40,8 @@ Plugin 已包含预构建的 MCP server 和 Widget。无需运行 `npm install`�
 codex plugin marketplace add Syh1906/openai-compatible-imagegen
 ```
 
+如果 `openai-compatible-imagegen` marketplace 已注册，跳过这一步。
+
 2. 安装 Plugin：
 
 ```text
@@ -48,7 +50,7 @@ codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
 
 3. 也可以在 Codex App 中打开 **Plugins**，或在交互式 Codex CLI 会话中输入 `/plugins`，选择 `openai-compatible-imagegen` marketplace，然后安装 **OpenAI-Compatible Images**。
 4. 使用 `codex plugin list --json` 确认已安装版本。
-5. 安装后开始一个新任务。
+5. 安装后完全退出并重新启动 Codex 一次，再开始新任务。
 6. 继续完成 [Plugin 配置](./configuration.zh-CN.md#配置-codex-plugin)。
 
 第一次配置也可以在新任务中要求 Agent 调用 `initialize_image_config`。使用 `inspect_image_config` 查看脱敏结果，使用 `update_image_config` 修改支持的字段。Plugin 安装目录和 Skill 目录不保存用户配置。
@@ -101,7 +103,7 @@ codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
    codex plugin add openai-compatible-imagegen@openai-compatible-imagegen
    ```
 
-6. 使用 `codex plugin list --json` 确认版本，然后开始一个新任务。
+6. 使用 `codex plugin list --json` 确认版本。完全退出并重新启动 Codex 一次，再开始新任务。
 7. 继续完成 [Plugin 配置](./configuration.zh-CN.md#配置-codex-plugin)。
 
 Codex 从 marketplace 目录安装 Plugin，不能直接从 ZIP 安装。只要仍在使用这个本地 marketplace，就需要保留解压目录。日常更新仍推荐使用 Git marketplace。

--- a/docs/guides/updating.md
+++ b/docs/guides/updating.md
@@ -1,46 +1,40 @@
-<!-- updated: 2026-08-19 -->
+<!-- updated: 2026-08-20 -->
 # Update the Plugin or Skill
 
 > Parent: [User guides](./README.md)
 
 Language: [简体中文](./updating.zh-CN.md)
 
-Use this guide to move an existing installation to a newer released version. Updating the package does not rewrite image-service credentials, user configuration, or generated artifacts.
+Use this guide to move an existing installation to a newer Git revision or released version. Updating the package does not rewrite image-service credentials, user configuration, or generated artifacts.
 
 ## Before you update
 
-- Read the target release notes for breaking configuration changes.
+- Choose the update channel. The Git marketplace follows the repository's default branch, while Release ZIP files provide fixed versions.
+- For a fixed version, read the target release notes for breaking configuration changes.
 - Keep the current installation and local configuration until the new version passes its smoke check.
 - Download release ZIP files and `SHA256SUMS` from the same GitHub Release when you need a fixed local package.
 
 ## Update a Git marketplace Plugin
 
-The marketplace command refreshes the configured Git snapshot. It is not a separate `plugin update` command and does not replace the installed Plugin by itself.
+When the Plugin system starts, Codex checks configured Git marketplaces. If this repository's default branch (`main`) has a new revision, Codex refreshes the marketplace snapshot and the installed Plugin cache. Run the marketplace upgrade command when you need to check immediately instead of waiting for the next startup.
 
 The `codex plugin` lifecycle commands below are identical in Windows PowerShell, macOS Terminal, and a Linux shell. Only local paths and platform utilities differ.
 
-1. Refresh the marketplace snapshot:
+1. Check for a new marketplace revision:
 
    ```text
    codex plugin marketplace upgrade openai-compatible-imagegen --json
    ```
 
-2. Replace the installed Plugin from the refreshed snapshot:
-
-   ```text
-   codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json
-   codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json
-   ```
-
-3. Confirm the installed version:
+2. Confirm the installed Plugin:
 
    ```text
    codex plugin list --json
    ```
 
-4. Start a new task in Codex App or a new CLI session before using the updated Skill or MCP tools. [OpenAI's official Plugin documentation](https://developers.openai.com/codex/plugins) requires a new chat or CLI session after installation.
+3. Completely quit and restart Codex once, then start a new task or CLI session. The restart loads the updated Skill, MCP tools, and bundled dependencies.
 
-If the marketplace source itself changed, remove and add the marketplace again before step 2. Do not use `--ref` unless you intentionally want a tag or branch snapshot.
+Do not remove and add the Plugin during a normal Git marketplace update. Use the Plugin ZIP or [Rollback](./rollback.md) route when you need a fixed release, archived build, different source, tag, or branch.
 
 ## Update from a Plugin ZIP
 

--- a/docs/guides/updating.zh-CN.md
+++ b/docs/guides/updating.zh-CN.md
@@ -1,46 +1,40 @@
-<!-- updated: 2026-08-19 -->
+<!-- updated: 2026-08-20 -->
 # 更新 Plugin 或 Skill
 
 > 上级：[用户指南](./README.zh-CN.md)
 
 [English](./updating.md) | 简体中文
 
-本指南用于把已有安装更新到较新的已发布版本。更新发行包不会重写图片服务凭据、用户配置或已生成的产物。
+本指南用于把已有安装更新到较新的 Git revision 或已发布版本。更新发行包不会重写图片服务凭据、用户配置或已生成的产物。
 
 ## 更新前检查
 
-- 阅读目标版本的 release notes，确认配置是否有不兼容变化。
+- 先选择更新渠道。Git marketplace 跟随仓库默认分支，Release ZIP 提供固定版本。
+- 使用固定版本时，阅读目标版本的 release notes，确认配置是否有不兼容变化。
 - 在新版本通过冒烟检查前保留当前安装和本地配置。
 - 需要固定版本的本地发行包时，从同一个 GitHub Release 下载 ZIP 和 `SHA256SUMS`。
 
 ## 更新 Git marketplace Plugin
 
-marketplace 命令只刷新已配置的 Git 快照；它不是单独的 `plugin update` 命令，也不会单独替换已经安装的 Plugin。
+Plugin 系统启动时，Codex 会检查已经配置的 Git marketplace。如果本仓库默认分支 `main` 出现新的 revision，Codex 会刷新 marketplace 快照和已安装 Plugin 的缓存。需要立即检查时，运行 marketplace upgrade 命令，不必等待下一次启动。
 
 下面的 `codex plugin` 生命周期命令在 Windows PowerShell、macOS 终端和 Linux shell 中相同。只有本地路径和平台工具不同。
 
-1. 刷新 marketplace 快照：
+1. 检查新的 marketplace revision：
 
    ```text
    codex plugin marketplace upgrade openai-compatible-imagegen --json
    ```
 
-2. 从刷新后的快照替换已安装 Plugin：
-
-   ```text
-   codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json
-   codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json
-   ```
-
-3. 确认已安装版本：
+2. 确认已安装 Plugin：
 
    ```text
    codex plugin list --json
    ```
 
-4. 在 Codex App 开始新任务，或开始新的 CLI 会话，再使用更新后的 Skill 或 MCP 工具。[OpenAI 官方 Plugin 文档](https://developers.openai.com/codex/plugins)要求安装后开始新的 chat 或 CLI session。
+3. 完全退出并重新启动 Codex 一次，再开始新任务或 CLI 会话。重启后会加载更新后的 Skill、MCP 工具和包内依赖。
 
-如果 marketplace 来源本身发生变化，在第 2 步前先删除并重新添加 marketplace。只有明确需要标签或分支快照时才使用 `--ref`。
+日常 Git marketplace 更新不需要删除并重新添加 Plugin。需要固定 Release、归档版本、其他来源、tag 或分支时，改用 Plugin ZIP 或[回滚](./rollback.zh-CN.md)路线。
 
 ## 从 Plugin ZIP 更新
 

--- a/tests/release/test_git_marketplace.mjs
+++ b/tests/release/test_git_marketplace.mjs
@@ -72,32 +72,61 @@ test("CI gives push and pull request checks distinct names", async () => {
 
 
 test("public install, update, and rollback guides use the documented plugin lifecycle commands", async () => {
-  const [readme, readmeZh, installation, updating, updatingZh, rollback, troubleshooting] = await Promise.all([
+  const [
+    readme,
+    readmeZh,
+    installation,
+    installationZh,
+    updating,
+    updatingZh,
+    rollback,
+    rollbackZh,
+    troubleshooting,
+    troubleshootingZh,
+  ] = await Promise.all([
     readFile(path.join(projectRoot, "README.md"), "utf8"),
     readFile(path.join(projectRoot, "README.zh-CN.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/installation.md"), "utf8"),
+    readFile(path.join(projectRoot, "docs/guides/installation.zh-CN.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/updating.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/updating.zh-CN.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/rollback.md"), "utf8"),
+    readFile(path.join(projectRoot, "docs/guides/rollback.zh-CN.md"), "utf8"),
     readFile(path.join(projectRoot, "docs/guides/troubleshooting.md"), "utf8"),
+    readFile(path.join(projectRoot, "docs/guides/troubleshooting.zh-CN.md"), "utf8"),
   ]);
 
   assert.match(readme, /\[简体中文\]\(README\.zh-CN\.md\)/);
   assert.match(readmeZh, /\[English\]\(README\.md\)/);
 
-  for (const document of [readme, readmeZh, installation]) {
+  for (const document of [readme, readmeZh, installation, installationZh]) {
     assert.match(document, /codex plugin marketplace add Syh1906\/openai-compatible-imagegen/);
     assert.match(document, /codex plugin add openai-compatible-imagegen@openai-compatible-imagegen/);
   }
-  for (const document of [updating, updatingZh]) {
+
+  for (const [document, marketplaceHeading, zipHeading, restartPattern] of [
+    [updating, "Update a Git marketplace Plugin", "Update from a Plugin ZIP", /completely quit and restart Codex/i],
+    [updatingZh, "更新 Git marketplace Plugin", "从 Plugin ZIP 更新", /完全退出并重新启动 Codex/],
+  ]) {
+    const marketplaceSection = markdownSection(document, marketplaceHeading);
+    const zipSection = markdownSection(document, zipHeading);
+
     for (const command of [
       "codex plugin marketplace upgrade openai-compatible-imagegen --json",
-      "codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json",
-      "codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json",
       "codex plugin list --json",
     ]) {
-      assert.ok(document.includes(command), `${command}: updating guide`);
+      assert.ok(marketplaceSection.includes(command), `${command}: ${marketplaceHeading}`);
     }
+    for (const command of [
+      "codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json",
+      "codex plugin add openai-compatible-imagegen@openai-compatible-imagegen --json",
+    ]) {
+      assert.ok(zipSection.includes(command), `${command}: ${zipHeading}`);
+    }
+    assert.doesNotMatch(marketplaceSection, /codex plugin (?:remove|add) /);
+    assert.doesNotMatch(marketplaceSection, /npm install/);
+    assert.match(marketplaceSection, restartPattern);
+
     for (const platformCommand of [
       '(Get-FileHash -Algorithm SHA256 -LiteralPath "openai-compatible-imagegen-codex-plugin-<version>.zip").Hash.ToLowerInvariant()',
       'shasum -a 256 openai-compatible-imagegen-codex-plugin-<version>.zip',
@@ -113,13 +142,27 @@ test("public install, update, and rollback guides use the documented plugin life
     assert.match(document, /auth\.json/);
   }
 
-  for (const command of [
-    "codex plugin list --json",
-    "codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json",
-    "codex plugin marketplace upgrade openai-compatible-imagegen --json",
-    "codex plugin marketplace remove openai-compatible-imagegen --json",
+  assert.match(readme, /marketplace is already registered[\s\S]*skip/i);
+  assert.match(readme, /completely quit and restart Codex/i);
+  assert.match(installation, /marketplace is already registered[\s\S]*skip/i);
+  assert.match(installation, /completely quit and restart Codex/i);
+  assert.match(readmeZh, /marketplace 已注册[\s\S]*跳过/);
+  assert.match(readmeZh, /完全退出并重新启动 Codex/);
+  assert.match(installationZh, /marketplace 已注册[\s\S]*跳过/);
+  assert.match(installationZh, /完全退出并重新启动 Codex/);
+
+  for (const documents of [
+    `${rollback}\n${troubleshooting}`,
+    `${rollbackZh}\n${troubleshootingZh}`,
   ]) {
-    assert.ok(`${rollback}\n${troubleshooting}`.includes(command), command);
+    for (const command of [
+      "codex plugin list --json",
+      "codex plugin remove openai-compatible-imagegen@openai-compatible-imagegen --json",
+      "codex plugin marketplace upgrade openai-compatible-imagegen --json",
+      "codex plugin marketplace remove openai-compatible-imagegen --json",
+    ]) {
+      assert.ok(documents.includes(command), command);
+    }
   }
 });
 
@@ -277,6 +320,14 @@ function fencedBodies(markdown) {
   return [...markdown.matchAll(/```[^\n]*\n([\s\S]*?)```/g)]
     .map((match) => match[1].trim().replaceAll(".zh-CN.md", ".md"))
     .sort();
+}
+
+function markdownSection(markdown, heading) {
+  const lines = markdown.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === `## ${heading}`);
+  assert.notEqual(start, -1, `missing section: ${heading}`);
+  const next = lines.findIndex((line, index) => index > start && /^#{1,2} /.test(line));
+  return lines.slice(start + 1, next === -1 ? undefined : next).join("\n");
 }
 
 function publicRelativeLinks(markdown) {


### PR DESCRIPTION
Codex refreshes installed Plugin caches when a configured Git marketplace revision changes, so normal marketplace updates no longer require removing and re-adding the Plugin.

This change:

- distinguishes the rolling Git marketplace channel from fixed Release ZIP versions;
- documents how to skip an already registered marketplace and fully restart Codex after installation or update;
- scopes lifecycle tests to the Git marketplace and Plugin ZIP sections while preserving rollback and troubleshooting commands.

This is a repository documentation correction only. It does not change runtime code, package versions, manifests, `dist/`, or release artifacts.

Validated with `npm run test:suite -- release`, `npm test`, and `git diff --check`.