### PR TITLE
修复发布 preflight 分支校验

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -59,7 +59,6 @@ jobs:
           expected_workflow_id="$(jq -r '.id' <<< "$workflow_json")"
           run_repository="$(jq -r '.repository.full_name' <<< "$run_json")"
           run_head_repository="$(jq -r '.head_repository.full_name' <<< "$run_json")"
-          default_branch="$(jq -r '.repository.default_branch' <<< "$run_json")"
           run_head_branch="$(jq -r '.head_branch' <<< "$run_json")"
           run_attempt="$(jq -r '.run_attempt' <<< "$run_json")"
           run_path="$(jq -r '.path' <<< "$run_json")"
@@ -75,7 +74,7 @@ jobs:
             echo "The Release preflight run does not belong to this repository." >&2
             exit 1
           fi
-          if [[ -z "$default_branch" || "$default_branch" == "null" || "$default_branch" != "$repository_default_branch" || "$run_head_branch" != "$default_branch" ]]; then
+          if [[ -z "$repository_default_branch" || "$repository_default_branch" == "null" || "$run_head_branch" != "$repository_default_branch" ]]; then
             echo "The Release preflight run must use the repository default branch." >&2
             exit 1
           fi
@@ -91,7 +90,7 @@ jobs:
             echo "The Release preflight run does not expose a valid run attempt." >&2
             exit 1
           fi
-          echo "default_branch=$default_branch" >> "$GITHUB_OUTPUT"
+          echo "default_branch=$repository_default_branch" >> "$GITHUB_OUTPUT"
           echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
       - name: Download verified preflight metadata

--- a/tests/test-infra/test_ci_platform.py
+++ b/tests/test-infra/test_ci_platform.py
@@ -91,6 +91,8 @@ class CiPlatformTests(unittest.TestCase):
         self.assertIn("GITHUB_WORKFLOW_REF", workflow)
         self.assertIn("CURRENT_REF_TYPE", workflow)
         self.assertIn("CURRENT_BRANCH", workflow)
+        self.assertIn('repository_default_branch="$(jq -r \'.default_branch\' <<< "$repository_json")"', workflow)
+        self.assertNotIn('default_branch="$(jq -r \'.repository.default_branch\' <<< "$run_json")"', workflow)
         self.assertIn("must run from the repository default branch", workflow)
         publish_start = workflow.index("  publish:")
         attempt_recheck = workflow.index("name: Revalidate the Release preflight attempt", publish_start)


### PR DESCRIPTION
修复 Publish release 对 Actions run 元数据的分支校验。\n\nGitHub Actions run API 的 repository.default_branch 可能为空，发布 workflow 改为使用仓库 API 的默认分支，并增加回归断言。该修复不改变产品代码、版本号、已验证候选或 v1.1.1 tag。\n\n验证：test-infra 41 项通过，git diff --check 通过。