### PR TITLE
修复发布候选元数据步骤顺序

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -93,6 +93,12 @@ jobs:
           echo "default_branch=$repository_default_branch" >> "$GITHUB_OUTPUT"
           echo "run_attempt=$run_attempt" >> "$GITHUB_OUTPUT"
           echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+      - name: Check out the authenticated preflight SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.preflight.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
       - name: Download verified preflight metadata
         uses: actions/download-artifact@v4
         with:
@@ -100,12 +106,6 @@ jobs:
           path: preflight-metadata
           run-id: ${{ inputs.preflight_run_id }}
           github-token: ${{ github.token }}
-      - name: Check out the authenticated preflight SHA
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.preflight.outputs.source_sha }}
-          fetch-depth: 0
-          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/tests/test-infra/test_ci_platform.py
+++ b/tests/test-infra/test_ci_platform.py
@@ -84,6 +84,10 @@ class CiPlatformTests(unittest.TestCase):
         self.assertIn("ref: ${{ needs.validate_release.outputs.preflight_sha }}", workflow)
         self.assertIn("candidate-windows-${{ needs.validate_release.outputs.run_attempt }}", workflow)
         self.assertIn("preflight-metadata-${{ steps.preflight.outputs.run_attempt }}", workflow)
+        self.assertLess(
+            workflow.index("name: Check out the authenticated preflight SHA"),
+            workflow.index("name: Download verified preflight metadata"),
+        )
         publish_start = workflow.index("  publish:")
         recheck = workflow.index("name: Revalidate the remote annotated tag", publish_start)
         create = workflow.index("name: Create the GitHub Release", publish_start)


### PR DESCRIPTION
调整 Publish release 的步骤顺序，先 checkout 固定 preflight SHA，再下载 preflight 元数据，避免 checkout 清理已下载文件。增加步骤顺序回归断言。\n\n验证：test-infra 41 项通过，git diff --check 通过。