### PR TITLE
修订 v1.1.1 发布说明

### DIFF
--- a/.github/release-notes/v1.1.1.md
+++ b/.github/release-notes/v1.1.1.md
@@ -1,21 +1,23 @@
-OpenAI-Compatible Images 1.1.1 adds user-configured model IDs, native transparency routing, and automatic result presentation for the Codex Plugin and Standalone Skill.
+OpenAI-Compatible Images 1.1.1 让你可以按供应商实际填写图片模型 ID，并在需要时使用原生透明图片。生成、编辑和交付成功后，Codex Plugin 会自动显示结果卡。
 
-## Highlights
+## 重点变化
 
-- Keep provider and model IDs in user configuration instead of restricting them to a code-level model list.
-- Add native transparency intent with a configurable capability declaration, one optional retry without the transparency parameter, and a configured local fallback route.
-- Preserve API originals and report the native parameter, retry decision, final transparency route, and QA result.
-- Guide first-time setup and upgrades through MCP configuration tools, including native transparency defaults and compatibility-preserving updates.
-- Automatically present successful generation, editing, batch, and delivery results in the Codex result card.
-- Start result-card image reads from stable IDs in standard tool input, even when the host does not project an optional tool-result notification.
+- 模型 ID 由配置决定，支持填写供应商使用的自定义值，不再受代码中的固定名称限制。
+- 透明图片支持原生参数。配置中的模型 ID 列表只用于声明能力，是否支持仍由供应商决定。
+- 供应商拒绝透明参数时，默认会去掉该参数重试一次，再按配置选择本地透明处理；你也可以关闭重试。
+- 透明请求的最终结果会说明是否使用了原生参数、是否重试，以及最后采用的处理路线。
+- 首次配置和升级时会保留已有配置；配置工具会提示透明设置和重新绑定项目所需的下一步。
+- 生成、编辑、批处理和交付成功后，结果会自动显示在 Codex 结果卡中。
 
-## Install
+## 安装
 
-Install the Codex Plugin from the Git-backed marketplace, or download the matching Plugin or Standalone archive together with `SHA256SUMS` from this Release. Verify the selected archive against `SHA256SUMS`, then follow the [v1.1.1 installation guide](https://github.com/Syh1906/openai-compatible-imagegen/blob/v1.1.1/docs/guides/installation.md).
+你可以从 Git marketplace 安装 Codex Plugin，也可以从本 Release 下载对应的 Plugin 或 Standalone 压缩包及 `SHA256SUMS`。先按校验文件核对压缩包，再阅读 [v1.1.1 安装指南](https://github.com/Syh1906/openai-compatible-imagegen/blob/v1.1.1/docs/guides/installation.zh-CN.md) 完成安装。
 
-Existing Plugin configuration is preserved. After upgrading, use `inspect_image_config`; if the native transparency section is missing, apply the documented `update_image_config` migration and rebind the project.
+升级不会覆盖已有的 Plugin 配置。升级后调用 `inspect_image_config`；如果配置中没有原生透明部分，按指南使用 `update_image_config` 更新，再重新绑定项目。
 
-## Known limitations
+## 已知限制
 
-- Native transparency support remains provider-dependent. When a provider rejects the transparency parameter, the configured retry and local fallback policy determine the final route.
-- macOS and Linux do not provide the Windows **Show in folder** action. Generation, editing, artifacts, annotations, and canvas workflows remain supported.
+- 原生透明是否成功取决于供应商。供应商拒绝透明参数时，最终路线由重试和本地处理配置决定。
+- macOS 和 Linux 不提供 Windows 的“在文件夹中显示”操作；生成、编辑、产物、标注和画布功能仍可用。
+
+本次只修订发布说明的表达方式和用户指引，不涉及发布包、版本内容或校验值变化。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # Changelog
 
-This file records user-visible changes for each release of `openai-compatible-imagegen`.
+这里记录 `openai-compatible-imagegen` 每个版本面向用户的变化。
 
 ## [1.1.1] - 2026-08-22
 
-### Added
+### 新增
 
-- Add optional provider-specific HTTP proxy URLs for generation, editing, and returned image downloads in both the Standalone Skill and Codex Plugin. Existing environment proxy behavior remains the default, and download-only direct mode retains priority when explicitly enabled.
-- Add user-configured model IDs and native transparency routing for Standalone and Plugin. Native transparency can retry once without the provider parameter and then use the configured local fallback route; results record the attempts and final QA route.
-- Automatically present successful generation, edit, batch, and delivery results in the result card; historical images remain available through `render_image_results`.
+- 可为 Standalone Skill 和 Codex Plugin 配置供应商专用的 HTTP 代理，用于生成、编辑和下载供应商返回的图片；未配置时仍沿用环境代理。
+- 模型 ID 由用户配置，支持供应商的自定义值。需要透明图片时，运行时会按配置尝试原生透明；供应商拒绝后默认去掉透明参数重试一次，再按配置使用本地透明处理。
+- 生成、编辑、批处理和交付成功后自动显示结果卡；历史图片仍可通过 `render_image_results` 查看。
 
-### Fixed
+### 修复
 
-- Prevent concurrent Codex Plugin tools from intermittently reporting a valid project binding as unavailable while another Plugin process refreshes it.
-- Update result cards immediately when the Codex host locale changes instead of waiting for a later artifact refresh.
-- Start result-card artifact reads from valid standard tool input even when the host omits a projected tool-result notification, avoiding an indefinite loading state.
+- 修复多个 Codex Plugin 工具并发刷新项目绑定时，偶尔把有效绑定报告为不可用的问题。
+- Codex 主机语言切换后，结果卡会立即更新，不再等待下一次产物刷新。
+- 修复部分主机未提供附加通知时结果卡一直读取中的问题。
 
 ## [1.1.0] - 2026-08-19
 

--- a/scripts/validate-release-notes.mjs
+++ b/scripts/validate-release-notes.mjs
@@ -4,7 +4,11 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 
 const projectRoot = fileURLToPath(new URL("..", import.meta.url));
-const requiredSections = ["Highlights", "Install", "Known limitations"];
+const requiredSections = [
+  ["Highlights", "重点变化"],
+  ["Install", "安装"],
+  ["Known limitations", "已知限制"],
+];
 
 
 export async function validateReleaseNotes({ projectRoot: root, releaseTag }) {
@@ -47,17 +51,19 @@ function validateNotesBody(notes, releaseTag) {
     const bodyEnd = headings[index + 1]?.index ?? normalized.length;
     sections.set(heading[1], normalized.slice(bodyStart, bodyEnd).trim());
   }
-  if (requiredSections.some((name) => !sections.get(name))) {
-    throw new Error("release notes must contain non-empty ## Highlights, ## Install, and ## Known limitations sections");
+  if (requiredSections.some((names) => !names.some((name) => sections.get(name)))) {
+    throw new Error("release notes must contain non-empty Highlights/重点变化, Install/安装, and Known limitations/已知限制 sections");
   }
   const firstSection = normalized.indexOf("\n## ");
   if (firstSection <= 0 || normalized.slice(0, firstSection).trim().length === 0) {
     throw new Error("release notes must start with a summary paragraph");
   }
-  if (!sections.get("Install").includes(`/blob/${releaseTag}/docs/guides/installation.md`)) {
+  const installSection = sections.get("Install") ?? sections.get("安装");
+  if (!installSection.includes(`/blob/${releaseTag}/docs/guides/installation.md`)
+    && !installSection.includes(`/blob/${releaseTag}/docs/guides/installation.zh-CN.md`)) {
     throw new Error(`the Install section must link to the ${releaseTag} installation guide`);
   }
-  if (!sections.get("Install").includes("SHA256SUMS")) {
+  if (!installSection.includes("SHA256SUMS")) {
     throw new Error("the Install section must require SHA256SUMS verification");
   }
   if (/(?:^|[\s("'])[A-Za-z]:[\\/]|(?:^|[\s("'])\/(?:home|Users)\//m.test(normalized)) {


### PR DESCRIPTION
## 变更说明

将 v1.1.1 的发布说明和变更记录统一改为面向用户的中文表达，补充模型 ID、原生透明、失败重试、升级兼容和结果卡的实际影响。

同时让发布说明校验器接受中文小标题与中文安装指南链接，保留现有英文格式兼容。

## 验证

- `node scripts/validate-release-notes.mjs --tag v1.1.1`
- `npm run test:smart`（51 项通过）
- `git diff --check`

不修改版本号、tag、发布附件或校验值。