### PR TITLE
补全 v1.4.0 发布说明的正式提交链接

### DIFF
--- a/.github/release-notes/v1.4.0.md
+++ b/.github/release-notes/v1.4.0.md
@@ -12,6 +12,7 @@ OpenAI-Compatible Images 1.4.0 为 API Key 请求增加 `xhigh`、`max` 质量�
 | 改动面 | 提交 | 内容 |
 | --- | --- | --- |
 | 模型参数、图片读取与指南 | [12560f6](https://github.com/Syh1906/openai-compatible-imagegen/commit/12560f6005b5f87fab90c28af12c508f8b824564) | 增加质量档位，修复自定义模型配置和慢读取，并更新配置、迁移及故障说明。 |
+| 等待状态与版本说明 | [9782827](https://github.com/Syh1906/openai-compatible-imagegen/commit/978282746da46d495cf5bc626c7222928ba41193) | 重新读取时重置等待提示，同步无障碍标签，并发布 1.4.0 更新与安装说明。 |
 
 完整提交历史与文件差异见 [v1.3.0 → v1.4.0](https://github.com/Syh1906/openai-compatible-imagegen/compare/v1.3.0...v1.4.0)，包含版本元数据与发布准备改动。
 


### PR DESCRIPTION
在 v1.4.0 发布说明中补入已合并的等待状态与无障碍标签修正提交，确保提交链接对应主分支正式历史。完整版本比较仍覆盖版本元数据和发布说明自身的更新。
