### PR TITLE
澄清 v1.5.0 发布说明的能力范围与使用前提

### DIFF
--- a/.github/release-notes/v1.5.0.md
+++ b/.github/release-notes/v1.5.0.md
@@ -4,17 +4,17 @@ OpenAI-Compatible Images 1.5.0 增加多供应商与模型配置，让画布可�
 
 - API Key 路线支持 v2 多供应商和模型配置，包括显示名称、别名、模型默认参数、独立生成与编辑端点，以及声明式参数字段。新增 xAI Images、Gemini Interactions 和 Gemini generateContent 协议适配器。
 - 画布可搜索并选择本次编辑的 API 模型和参数。选择随草稿保存并绑定提交，不修改默认模型；ChatGPT 继续使用 Codex 内置路线。用户配置新增 `canvas_submission_mode`，可选择将编辑要求填入输入框等待发送，或直接发送。
-- Standalone 增加 `list-models`、`--profile` 和 `--parameters`；生成、编辑及批处理命令接受 `--transparency-route native-alpha`。显式 `plugin-v1` 迁移保留原活动模型和宿主的默认参数，其他模型不继承这些参数。
-- 方图、横图和竖图在结果卡中完整缩放；宿主限制结果区高度时，可以在结果区内滚动查看后续卡片。最终交付汇总需要交付或比较的图片，并优先展示修改后的最终版本。
+- Standalone 增加 `list-models`、`--profile` 和 `--parameters`；在配置中启用原生透明后，生成、编辑及批处理命令可通过 `--transparency-route native-alpha` 为单次请求选择该路线。显式 `plugin-v1` 迁移保留原活动模型和宿主的默认参数，其他模型不继承这些参数。
+- 方图、横图和竖图在结果卡中完整缩放；宿主限制结果区高度时，可以在结果区内滚动查看后续卡片。多次生成和编辑后，最终回复会集中展示所需图片，并优先展示最终编辑版本。
 - 修复 Standalone v2 批处理参数覆盖、透明与素材请求的 PNG 要求、迁移脚本从安装目录之外运行，以及活动模型透明策略查询问题。
 
 ## 涉及提交
 
 | 改动面 | 提交 | 内容 |
 | --- | --- | --- |
-| 最终图片交付 | [69efa6d](https://github.com/Syh1906/openai-compatible-imagegen/commit/69efa6d8897d3905279564731247e937da0fdb2d) | 汇总跨操作的最终交付图片，保留版本选择与完整展示要求。 |
+| 最终图片交付 | [69efa6d](https://github.com/Syh1906/openai-compatible-imagegen/commit/69efa6d8897d3905279564731247e937da0fdb2d) | 多次生成或编辑后，最终回复集中展示所需图片。 |
 | 多协议配置与画布选模 | [d16fa32](https://github.com/Syh1906/openai-compatible-imagegen/commit/d16fa32f790702f24e855354f64f167b178ace70) | 增加供应商适配器、模型目录与画布选择，更新迁移、参数和使用指南。 |
-| 结果卡布局 | [0c55037](https://github.com/Syh1906/openai-compatible-imagegen/commit/0c550377cd99c699d68d1c2c27025ab8a3f4fa46) | 修复图片裁剪与结果区滚动，补齐布局变更的三平台检查。 |
+| 结果卡布局 | [0c55037](https://github.com/Syh1906/openai-compatible-imagegen/commit/0c550377cd99c699d68d1c2c27025ab8a3f4fa46) | 图片在结果卡中完整显示，高度受限时可滚动查看后续图片。 |
 | 原生透明参数与说明 | [d96f8ca](https://github.com/Syh1906/openai-compatible-imagegen/commit/d96f8cad33fe8692b1cfe5d884007a02b835c15e) | 补齐 Standalone 原生透明参数，并澄清配置范围、候选发布和画布提交说明。 |
 
 完整提交历史与文件差异见 [v1.4.0 → v1.5.0](https://github.com/Syh1906/openai-compatible-imagegen/compare/v1.4.0...v1.5.0)，包含版本元数据与发布准备改动。
@@ -33,6 +33,6 @@ OpenAI-Compatible Images 1.5.0 增加多供应商与模型配置，让画布可�
 ## 已知限制
 
 - 模型与参数选择属于 API Key 路线；ChatGPT 路线的模型和生成参数由 Codex 宿主控制。请求不支持的参数时不会自动切换模型、供应商或协议。
-- 编辑、mask、多参考图和原生透明能力取决于所选协议与供应商配置。xAI Images 和两种 Gemini 协议不提供 mask 或原生透明输出；具体差异见[模型与协议指南](https://github.com/Syh1906/openai-compatible-imagegen/blob/v1.5.0/docs/guides/models.zh-CN.md)。Gemini Interactions 的在线生成与编辑兼容性尚待确认。
+- 编辑、mask、多参考图和原生透明能力取决于所选协议与供应商配置。当前 xAI Images 和两种 Gemini 适配器不支持专用 mask 或 `native-alpha` 请求参数；具体差异见[模型与协议指南](https://github.com/Syh1906/openai-compatible-imagegen/blob/v1.5.0/docs/guides/models.zh-CN.md)。Gemini Interactions 的在线生成与编辑兼容性尚待确认。
 - 部分 Codex App 中，画布或图片预览首次展开仍可能白屏，恢复方法见[故障排查](https://github.com/Syh1906/openai-compatible-imagegen/blob/v1.5.0/docs/guides/troubleshooting.zh-CN.md)。
 - macOS 和 Linux 不提供 Windows 的“在文件夹中显示”操作。


### PR DESCRIPTION
澄清 v1.5.0 发布说明中的原生透明配置前提和协议参数限制，并将结果卡与最终图片交付说明调整为用户可感知的行为。

仅修改 Release 正文，两种发行包的内容不变。已通过智能回归、发行说明校验和差异检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that native transparency must be enabled in configuration before using the `native-alpha` transparency route per request.
  - Updated final-delivery guidance to explain that the final reply consolidates and prioritizes the final edited version.
  - Clarified multi-protocol configuration and result-card layout descriptions.
  - Updated known limitations for xAI Images and Gemini adapters regarding dedicated mask and `native-alpha` request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->